### PR TITLE
ruby dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM linuxbrew/linuxbrew:latest
 LABEL maintainer="pav <pavegy@gmail.com>"
 
 ENV TZ "Asia/Tokyo"
-RUN sudo apt-get update && sudo apt-get install -y bison tzdata && \
+RUN sudo apt-get update && sudo apt-get install -y bison tzdata libssl-dev zlib1g-dev && \
   sudo locale-gen ja_JP.UTF-8 && \
   sudo update-locale LANG=ja_JP.UTF-8 && \
   sudo ln -sf /usr/share/zoneinfo/Azia/Tokyo /etc/localtime


### PR DESCRIPTION
when error occurred install ruby from rbenv.

```bash
2e4e3def3ddc ❯❯❯ rbenv install 2.6.3
no such command 'init'
Usage: tfenv <command> [<options>]

Commands:
   install       Install a specific version of Terraform
   use           Switch a version to use
   uninstall     Uninstall a specific version of Terraform
   list          List all installed versions
   list-remote   List all installable versions

Downloading ruby-2.6.3.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2
Installing ruby-2.6.3...
ruby-build: using readline from homebrew

BUILD FAILED (Ubuntu 16.04 using ruby-build 20190615-7-g0e9094b)

Inspect or clean up the working tree at /tmp/ruby-build.20190803212237.19826
Results logged to /tmp/ruby-build.20190803212237.19826.log

Last 10 log lines:
The Ruby openssl extension was not compiled.
The Ruby zlib extension was not compiled.
ERROR: Ruby install aborted due to missing extensions
Try running `apt-get install -y libssl-dev zlib1g-dev` to fetch missing dependencies.

Configure options used:
  --prefix=/home/linuxbrew/.anyenv/envs/rbenv/versions/2.6.3
  --with-readline-dir=/home/linuxbrew/.linuxbrew/opt/readline
  LDFLAGS=-L/home/linuxbrew/.anyenv/envs/rbenv/versions/2.6.3/lib
  CPPFLAGS=-I/home/linuxbrew/.anyenv/envs/rbenv/versions/2.6.3/include
```

when I add line, it was succeded.
