### PR TITLE
python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM linuxbrew/linuxbrew:latest
 LABEL maintainer="pav <pavegy@gmail.com>"
 
 ENV TZ "Asia/Tokyo"
-RUN sudo apt-get update && sudo apt-get install -y bison tzdata && \
+RUN sudo apt-get update && \
+  sudo apt-get install -y bison tzdata libssl-dev zlib1g-dev libffi-dev && \
   sudo locale-gen ja_JP.UTF-8 && \
   sudo update-locale LANG=ja_JP.UTF-8 && \
   sudo ln -sf /usr/share/zoneinfo/Azia/Tokyo /etc/localtime


### PR DESCRIPTION
python build was failed.
I add to libffi-dev, fix it.


```
2e4e3def3ddc ❯❯❯ sudo apt install libffi-dev
パッケージリストを読み込んでいます... 完了
依存関係ツリーを作成しています
状態情報を読み取っています... 完了
以下のパッケージが新たにインストールされます:
  libffi-dev
アップグレード: 0 個、新規インストール: 1 個、削除: 0 個、保留: 54 個。
161 kB のアーカイブを取得する必要があります。
この操作後に追加で 365 kB のディスク容量が消費されます。
取得:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libffi-dev amd64 3.2.1-4 [161 kB]
161 kB を 1秒 で取得しました (94.3 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
以前に未選択のパッケージ libffi-dev:amd64 を選択しています。
(データベースを読み込んでいます ... 現在 17016 個のファイルとディレクトリがインストールされています。)
.../libffi-dev_3.2.1-4_amd64.deb を展開する準備をしています ...
libffi-dev:amd64 (3.2.1-4) を展開しています...
libffi-dev:amd64 (3.2.1-4) を設定しています ...

~/dotfiles master*
2e4e3def3ddc ❯❯❯ pyenv install 3.7.4
Downloading Python-3.7.4.tgz...
-> https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz
Installing Python-3.7.4...
python-build: use readline from homebrew
WARNING: The Python bz2 extension was not compiled. Missing the bzip2 lib?
WARNING: The Python readline extension was not compiled. Missing the GNU readline lib?
WARNING: The Python sqlite3 extension was not compiled. Missing the SQLite3 lib?
Installed Python-3.7.4 to /home/linuxbrew/.anyenv/envs/pyenv/versions/3.7.4


~/dotfiles master* 2m 11s
2e4e3def3ddc ❯❯❯ pyenv rehash

~/dotfiles master*
2e4e3def3ddc ❯❯❯ pyenv versions
* system (set by /home/linuxbrew/.anyenv/envs/pyenv/version)
  3.7.4

~/dotfiles master*
2e4e3def3ddc ❯❯❯ pyenv global 3.7.4

~/dotfiles master*
2e4e3def3ddc ❯❯❯ python
Python 3.7.4 (default, Aug  3 2019, 21:39:18)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print "a"
  File "<stdin>", line 1
    print "a"
            ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("a")?
>>> print('a')
a
>>>
```